### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "friday"
       time: "21:00"
       timezone: "Asia/Tokyo"
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "pnpm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
+      timezone: "Asia/Tokyo"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@ markdown の Linter 系の設定を自分用にまとめたもの。
 
 * [textlint と VS Code で始める文章校正 - Qiita](https://qiita.com/takasp/items/22f7f72b691fda30aea2)
 * [textlint-ja/textlint-rule-preset-ja-technical-writing： 技術文書向けのtextlintルールプリセット](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)
+
+## Dependabot Configuration
+
+This repository uses Dependabot to manage dependencies. Dependabot is configured to check for updates every Friday at 21:00 JST.
+
+### Package Ecosystem
+
+- **npm**
+- **pnpm**
+
+### Directory
+
+Dependabot is configured to check the root directory of the repository.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ markdown の Linter 系の設定を自分用にまとめたもの。
 
 ## Dependabot Configuration
 
-This repository uses Dependabot to manage dependencies. Dependabot is configured to check for updates every Friday at 21:00 JST.
+このリポジトリでは Dependabot を使用して依存関係を管理しています。Dependabot は毎週金曜日の21:00 JSTに更新をチェックするように設定されています。
 
-### Package Ecosystem
+### パッケージエコシステム
 
 - **npm**
 - **pnpm**
 
-### Directory
+### ディレクトリ
 
-Dependabot is configured to check the root directory of the repository.
+Dependabot はリポジトリのルートディレクトリをチェックするように設定されています。


### PR DESCRIPTION
Add Dependabot configuration to the repository.

* **README.md**
  - Add a section about Dependabot configuration.
  - Mention the schedule for Dependabot updates.
  - Specify the package ecosystems as "npm" and "pnpm".
  - Set the directory to the root of the repository.

* **.github/dependabot.yml**
  - Create a new file to configure Dependabot.
  - Set the update schedule to Friday at 21:00 JST.
  - Specify the package ecosystems as "npm" and "pnpm".
  - Set the directory to the root of the repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yumechi/my-markdown-writing-setting/pull/7?shareId=54f7e6b8-d0e7-44a3-8512-82e3a79b2a92).