### PR TITLE
Add GitHub Actions workflow for auto-merging Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,22 @@
+name: Auto Merge Dependabot PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Merge Dependabot PRs
+        if: github.actor == 'dependabot[bot]'
+        run: gh pr merge ${{ github.event.pull_request.number }} --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ markdown の Linter 系の設定を自分用にまとめたもの。
 ### ディレクトリ
 
 Dependabot はリポジトリのルートディレクトリをチェックするように設定されています。
+
+## GitHub Actions
+
+このリポジトリでは、Dependabot からのプルリクエストを自動的にマージするための GitHub Actions ワークフローを使用しています。新しいワークフローは `auto-merge-dependabot.yml` というファイルに記述されています。


### PR DESCRIPTION
Add GitHub Actions workflow to auto-merge Dependabot PRs.

* **README.md**
  - Add a new section "## GitHub Actions" to describe the new GitHub Actions workflow for auto-merging Dependabot PRs.
  - Mention the new workflow file `auto-merge-dependabot.yml` in the new section.

* **.github/workflows/auto-merge-dependabot.yml**
  - Create a new GitHub Actions workflow file to auto-merge Dependabot PRs.
  - Use the `pull_request_target` event to trigger the workflow.
  - Add a job named `auto-merge` that runs on `ubuntu-latest`.
  - Use the `actions/checkout@v4` action to check out the repository.
  - Use the `gh pr merge` command to merge Dependabot PRs if `github.actor` is `dependabot[bot]`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yumechi/my-markdown-writing-setting/pull/13?shareId=e8291e01-8456-4d31-ab0a-b225c053ea4b).