### PR TITLE
Add manual GitHub Actions workflow to merge all open Dependabot PRs

### DIFF
--- a/.github/workflows/manual-merge-dependabot.yml
+++ b/.github/workflows/manual-merge-dependabot.yml
@@ -1,0 +1,23 @@
+name: Manual Merge Dependabot PRs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  list-dependabot-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List Dependabot PRs
+        run: |
+          gh pr list --author dependabot[bot] --json number,title,url
+
+  merge-dependabot-prs:
+    needs: list-dependabot-prs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Dependabot PRs
+        run: |
+          prs=$(gh pr list --author dependabot[bot] --json number --jq '.[].number')
+          for pr in $prs; do
+            gh pr merge $pr --merge
+          done


### PR DESCRIPTION
Add a new GitHub Actions workflow to manually merge all open Dependabot PRs.

* **.github/workflows/manual-merge-dependabot.yml**
  - Define a new workflow triggered by `workflow_dispatch`.
  - Add a job to list all open PRs created by Dependabot.
  - Add a job to merge each open PR created by Dependabot.

