### PR TITLE
Add manual merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/manual-merge-dependabot.yml
+++ b/.github/workflows/manual-merge-dependabot.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   list-dependabot-prs:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: List Dependabot PRs
         run: |
@@ -14,6 +16,8 @@ jobs:
   merge-dependabot-prs:
     needs: list-dependabot-prs
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Merge Dependabot PRs
         run: |


### PR DESCRIPTION
Add `GH_TOKEN` environment variable to GitHub Actions workflow for manual merging of Dependabot PRs.

* Add `env` section to set `GH_TOKEN` environment variable in `list-dependabot-prs` job
* Add `env` section to set `GH_TOKEN` environment variable in `merge-dependabot-prs` job

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yumechi/my-markdown-writing-setting/pull/15?shareId=54a7d8a0-ff1a-43cf-85f1-2741fa8c8e05).