### PR TITLE
fix: pnpm.overridesでhono/@hono/node-serverの脆弱性を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "pnpm": {
     "overrides": {
       "@modelcontextprotocol/sdk": ">=1.26.0",
-      "hono": ">=4.12.7",
-      "@hono/node-server": ">=1.19.10",
+      "hono": ">=4.12.12",
+      "@hono/node-server": ">=1.19.13",
       "minimatch": ">=10.2.3",
       "flatted": ">=3.4.2",
       "express-rate-limit": ">=8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 overrides:
   '@modelcontextprotocol/sdk': '>=1.26.0'
-  hono: '>=4.12.7'
-  '@hono/node-server': '>=1.19.10'
+  hono: '>=4.12.12'
+  '@hono/node-server': '>=1.19.13'
   minimatch: '>=10.2.3'
   flatted: '>=3.4.2'
   express-rate-limit: '>=8.2.2'
@@ -95,7 +95,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.7'
+      hono: '>=4.12.12'
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}


### PR DESCRIPTION
## Summary

- Dependabot PR #75 (hono 4.12.7→4.12.12) / #74 (@hono/node-server 1.19.10→1.19.13) が直近の `package.json` 変更 (commit 19ba00c) と衝突していたため、PR #70・#76 と同じ方針で `pnpm.overrides` の値を引き上げて手元で対応する
- 修正対象 CVE / GHSA:
  - **hono >=4.12.12**
    - GHSA-wmmm-f939-6g9c: serveStatic で repeated slashes による middleware bypass
    - GHSA-xf4j-xp2r-rqqx: `toSSG()` の path traversal
    - GHSA-xpcf-pg52-r92g: `ipRestriction()` で IPv4-mapped IPv6 アドレスの不正一致
    - GHSA-26pp-8wgv-hjvm: `setCookie()` の cookie name 検証欠落
    - GHSA-r5rp-j6wh-rvv4: `getCookie()` の non-breaking space prefix bypass
  - **@hono/node-server >=1.19.13**
    - GHSA-92pp-h63x-v22m: serve-static で repeated slashes による middleware bypass

## Test plan

- [x] `pnpm install` で `pnpm-lock.yaml` の差分が overrides セクションと peerDependencies のみに収まることを確認
- [x] `pnpm-lock.yaml` 内で `hono@4.12.12` / `@hono/node-server@1.19.13` に到達していることを確認
- [x] `pnpm textlint --version` および stdin lint が正常終了することを smoke test で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)