### PR TITLE
chore: pnpm を 10.32.1 から 11.6.0 にアップグレード

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 nodejs = "24.13.0"
-"npm:pnpm" = "10.32.1"
+"npm:pnpm" = "11.6.0"

--- a/package.json
+++ b/package.json
@@ -11,21 +11,6 @@
     "textlint-rule-prh": "6.1.0",
     "textlint-rule-spellcheck-tech-word": "5.0.0"
   },
-  "pnpm": {
-    "overrides": {
-      "@modelcontextprotocol/sdk": ">=1.26.0",
-      "hono": ">=4.12.14",
-      "@hono/node-server": ">=1.19.13",
-      "minimatch": ">=10.2.3",
-      "flatted": ">=3.4.2",
-      "express-rate-limit": ">=8.2.2",
-      "prh>diff": ">=4.0.4",
-      "qs": ">=6.14.2",
-      "brace-expansion": ">=5.0.5",
-      "path-to-regexp": ">=8.4.0",
-      "lodash": ">=4.18.0"
-    }
-  },
   "devDependencies": {
     "textlint-filter-rule-comments": "1.3.0"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+overrides:
+  "@modelcontextprotocol/sdk": ">=1.26.0"
+  hono: ">=4.12.14"
+  "@hono/node-server": ">=1.19.13"
+  minimatch: ">=10.2.3"
+  flatted: ">=3.4.2"
+  express-rate-limit: ">=8.2.2"
+  "prh>diff": ">=4.0.4"
+  qs: ">=6.14.2"
+  brace-expansion: ">=5.0.5"
+  path-to-regexp: ">=8.4.0"
+  lodash: ">=4.18.0"


### PR DESCRIPTION
## 変更概要

pnpm をバージョン 10.32.1 から 11.6.0 にアップグレードします。

## コミット

- chore: pnpm を 10.32.1 から 11.6.0 にアップグレード